### PR TITLE
Fix Solr HDFS and Backcompat tests

### DIFF
--- a/solr/core/src/test/org/apache/solr/backcompat/TestLuceneIndexBackCompat.java
+++ b/solr/core/src/test/org/apache/solr/backcompat/TestLuceneIndexBackCompat.java
@@ -31,9 +31,11 @@ import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.index.TestBackwardsCompatibility;
 import org.apache.lucene.util.TestUtil;
+import org.apache.lucene.util.crypto.Crypto;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.util.TestHarness;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Verify we can read/write previous versions' Lucene indexes. */
@@ -41,6 +43,12 @@ public class TestLuceneIndexBackCompat extends SolrTestCaseJ4 {
   private static final String[] oldNames = TestBackwardsCompatibility.getOldNames();
   private static final String[] oldSingleSegmentNames = TestBackwardsCompatibility.getOldSingleSegmentNames();
 
+  @Before
+  public void beforeFunction() {
+    // This test is done with premade unencrypted indexes. Need to turn off encryption
+    Crypto.setEncryptionOn(false);
+  }
+  
   @Test
   public void testOldIndexes() throws Exception {
     List<String> names = new ArrayList<>(oldNames.length + oldSingleSegmentNames.length);


### PR DESCRIPTION
Adds index decryption for [HDFS](https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html) Directory.
This fixes all HDFS-related tests, including (but not limited to):
```
   [junit4]   - org.apache.solr.cloud.api.collections.TestHdfsCloudBackupRestore.test
   [junit4]   - org.apache.solr.cloud.hdfs.HdfsNNFailoverTest.test
   [junit4]   - org.apache.solr.index.hdfs.CheckHdfsIndexTest.doTest
   [junit4]   - org.apache.solr.index.hdfs.CheckHdfsIndexTest.testChecksumsOnly
   [junit4]   - org.apache.solr.index.hdfs.CheckHdfsIndexTest.testDeletedDocs
   [junit4]   - org.apache.solr.index.hdfs.CheckHdfsIndexTest.testChecksumsOnlyVerbose
   [junit4]   - org.apache.solr.update.TestHdfsUpdateLog.testFSThreadSafety
   [junit4]  -  org.apache.solr.store.hdfs.HdfsDirectoryTest
   ...
```

Also back-compat test is now fixed
```
   [junit4]   -  org.apache.solr.backcompat.TestLuceneIndexBackCompat.testOldIndexes
```
