### PR TITLE
Encryption cleanup

### DIFF
--- a/lucene/core/build.xml
+++ b/lucene/core/build.xml
@@ -29,12 +29,9 @@
   <property name="moman.commit-hash" value="5c5c2a1e4dea" />
   <property name="moman.url" value="https://bitbucket.org/jpbarrette/moman/get/${moman.commit-hash}.zip" />
 
-  <path id="classpath">
-    <fileset dir="lib"/>
-  </path>
+  <path id="classpath"/>
   
   <path id="test.classpath">
-    <path refid="classpath"/>
     <pathelement location="${common.dir}/build/codecs/classes/java"/>
     <pathelement location="${common.dir}/build/test-framework/classes/java"/>
     <path refid="junit-path"/>

--- a/lucene/core/ivy.xml
+++ b/lucene/core/ivy.xml
@@ -18,12 +18,4 @@
 -->
 <ivy-module version="2.0">
   <info organisation="org.apache.lucene" module="core"/>
-  <configurations defaultconfmapping="compile->master">
-    <conf name="compile" transitive="false"/>
-  </configurations>
-  <dependencies>
-    <dependency org="org.apache.commons" name="commons-crypto" rev="${/org.apache.commons/commons-crypto}" conf="compile"/>
-    <dependency org="org.apache.commons" name="commons-compress" rev="${/org.apache.commons/commons-compress}" conf="compile"/>
-    <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="${/com.fasterxml.jackson.core/jackson-databind}" conf="compile"/>
-  </dependencies>
 </ivy-module>

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -70,19 +70,21 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     this.chunkSizeMask = (1L << chunkSizePower) - 1L;
     this.guard = guard;
     this.isMmap = (resourceDescription != null && resourceDescription.contains("MMapIndexInput("));
-    
-    if (this.isMmap && Crypto.isEncryptionOn()) {
-      try {
-        this.cipher = Crypto.getCtrDecryptCipher(Crypto.GetAesKey(), Crypto.GetAesIV());
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }      
-    } else {
-      this.cipher = null;
-    }
+    this.cipher = initCipher();
 
     assert chunkSizePower >= 0 && chunkSizePower <= 30;
     assert (length >>> chunkSizePower) < Integer.MAX_VALUE;
+  }
+  
+  private CtrCipher initCipher() {
+    if (this.isMmap && Crypto.isEncryptionOn()) {
+      try {
+        return Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
+      } catch (IOException e) {
+        return null;
+      }      
+    }
+    return null;
   }
 
   public byte decryptByte(byte b, long pos) throws GeneralSecurityException, IOException {

--- a/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
@@ -175,7 +175,7 @@ public class NIOFSDirectory extends FSDirectory {
       
       CtrCipher cipher = null;
       if (Crypto.isEncryptionOn()) {
-        cipher = Crypto.getCtrDecryptCipher(Crypto.GetAesKey(), Crypto.GetAesIV());        
+        cipher = Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
       }
 
       try {

--- a/lucene/core/src/java/org/apache/lucene/store/SimpleFSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/SimpleFSDirectory.java
@@ -172,7 +172,7 @@ public class SimpleFSDirectory extends FSDirectory {
         
         CtrCipher cipher = null;
         if (Crypto.isEncryptionOn()) {
-          cipher = Crypto.getCtrDecryptCipher(Crypto.GetAesKey(), Crypto.GetAesIV());        
+          cipher = Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
         }
 
         try {

--- a/lucene/core/src/java/org/apache/lucene/util/crypto/Crypto.java
+++ b/lucene/core/src/java/org/apache/lucene/util/crypto/Crypto.java
@@ -58,38 +58,38 @@ public final class Crypto {
     return encryptionOn.get();
   }
 
-  public static void Initialize() throws NoSuchAlgorithmException {
+  public static void initialize() throws NoSuchAlgorithmException {
     Security.setProperty("crypto.policy", "unlimited");
-    GetSecureRandom();
+    getSecureRandom();
   }
 
-  public static SecretKey GetAesKey() {
+  public static SecretKey getAesKey() {
     if (isEncryptionOn()) {
       return TEST_AES_KEY;
     }
     return null;
   }
 
-  public static IvParameterSpec GetAesIV() {
+  public static IvParameterSpec getAesIV() {
     if (isEncryptionOn()) {
       return TEST_AES_IV;
     }
     return null;
   }
 
-  public static SecretKey GenerateAesKey() throws NoSuchAlgorithmException {
+  public static SecretKey generateAesKey() throws NoSuchAlgorithmException {
     KeyGenerator keyGen = KeyGenerator.getInstance("AES");
     keyGen.init(AES_KEY_SIZE);
     return keyGen.generateKey();
   }
 
-  public static IvParameterSpec GenerateAesIV() throws NoSuchAlgorithmException {
+  public static IvParameterSpec generateAesIV() throws NoSuchAlgorithmException {
     byte[] iv = new byte[AES_BLOCK_SIZE];
-    GetSecureRandom().nextBytes(iv);
+    getSecureRandom().nextBytes(iv);
     return new IvParameterSpec(iv);
   }
 
-  public static SecureRandom GetSecureRandom() throws NoSuchAlgorithmException {
+  static SecureRandom getSecureRandom() throws NoSuchAlgorithmException {
     if (rand == null) {
       synchronized (Crypto.class) {
         if (rand == null) {
@@ -100,26 +100,24 @@ public final class Crypto {
     return rand;
   }
 
-  public static Cipher InitAesCtrCipherEncrypt(SecretKey key, IvParameterSpec iv)
-      throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException,
-      InvalidAlgorithmParameterException {
-    if (isEncryptionOn()) {
+  public static Cipher getCtrEncryptCipher(SecretKey key, IvParameterSpec iv) throws IOException {
+    try {
       Cipher cipher = Cipher.getInstance(CTR_TRANSFORM);
       cipher.init(Cipher.ENCRYPT_MODE, key, iv);
       return cipher;
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
+      throw new IOException(e);
     }
-    return null;
   }
 
-  public static byte[] EncryptAesCtr(SecretKey key, IvParameterSpec iv, byte[] plaintext)
-      throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException,
-      BadPaddingException, InvalidAlgorithmParameterException {
-    if (isEncryptionOn()) {
-      Cipher cipher = Cipher.getInstance(CTR_TRANSFORM);
-      cipher.init(Cipher.ENCRYPT_MODE, key, iv);
+  public static byte[] encryptAesCtr(SecretKey key, IvParameterSpec iv, byte[] plaintext)
+      throws IOException {
+    try {
+      Cipher cipher = getCtrEncryptCipher(key, iv);
       return cipher.doFinal(plaintext);
+    } catch (IllegalBlockSizeException | BadPaddingException e) {
+      throw new IOException(e);
     }
-    return plaintext;
   }
 
   public static CtrCipher getCtrDecryptCipher(SecretKey key, IvParameterSpec iv) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/util/crypto/Crypto.java
+++ b/lucene/core/src/java/org/apache/lucene/util/crypto/Crypto.java
@@ -18,15 +18,12 @@
 package org.apache.lucene.util.crypto;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.util.Base64;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.crypto.BadPaddingException;
@@ -37,8 +34,6 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-
-import org.apache.commons.crypto.stream.CtrCryptoInputStream;
 
 public final class Crypto {
 
@@ -125,18 +120,6 @@ public final class Crypto {
       return cipher.doFinal(plaintext);
     }
     return plaintext;
-  }
-
-  public static CtrCryptoInputStream GetCtrCryptoInputStream(InputStream stream, byte[] key, byte[] iv)
-      throws GeneralSecurityException, IOException {
-    Security.setProperty("crypto.policy", "unlimited");
-    return new CtrCryptoInputStream(new Properties(), stream, key, iv, 0);
-  }
-
-  public static CtrCryptoInputStream GetCtrCryptoInputStream(InputStream stream, byte[] key, byte[] iv, long offset)
-      throws GeneralSecurityException, IOException {
-    Security.setProperty("crypto.policy", "unlimited");
-    return new CtrCryptoInputStream(new Properties(), stream, key, iv, offset);
   }
 
   public static CtrCipher getCtrDecryptCipher(SecretKey key, IvParameterSpec iv) throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/util/crypto/SeekableInMemoryByteChannel.java
+++ b/lucene/core/src/test/org/apache/lucene/util/crypto/SeekableInMemoryByteChannel.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Local copy from
+// https://github.com/apache/commons-compress/blob/master/src/main/java/org/apache/commons/compress/utils/SeekableInMemoryByteChannel.java
+
+package org.apache.lucene.util.crypto;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@link SeekableByteChannel} implementation that wraps a byte[].
+ *
+ * <p>When this channel is used for writing an internal buffer grows to accommodate
+ * incoming data. A natural size limit is the value of {@link Integer#MAX_VALUE}.
+ * Internal buffer can be accessed via {@link SeekableInMemoryByteChannel#array()}.</p>
+ *
+ * @since 1.13
+ * @NotThreadSafe
+ */
+public class SeekableInMemoryByteChannel implements SeekableByteChannel {
+
+    private static final int NAIVE_RESIZE_LIMIT = Integer.MAX_VALUE >> 1;
+
+    private byte[] data;
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private int position, size;
+
+    /**
+     * Constructor taking a byte array.
+     *
+     * <p>This constructor is intended to be used with pre-allocated buffer or when
+     * reading from a given byte array.</p>
+     *
+     * @param data input data or pre-allocated array.
+     */
+    public SeekableInMemoryByteChannel(byte[] data) {
+        this.data = data;
+        size = data.length;
+    }
+
+    /**
+     * Parameterless constructor - allocates internal buffer by itself.
+     */
+    public SeekableInMemoryByteChannel() {
+        this(new byte[0]);
+    }
+
+    /**
+     * Constructor taking a size of storage to be allocated.
+     *
+     * <p>Creates a channel and allocates internal storage of a given size.</p>
+     *
+     * @param size size of internal buffer to allocate, in bytes.
+     */
+    public SeekableInMemoryByteChannel(int size) {
+        this(new byte[size]);
+    }
+
+    @Override
+    public long position() {
+        return position;
+    }
+
+    @Override
+    public SeekableByteChannel position(long newPosition) throws IOException {
+        ensureOpen();
+        if (newPosition < 0L || newPosition > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Position has to be in range 0.. " + Integer.MAX_VALUE);
+        }
+        position = (int) newPosition;
+        return this;
+    }
+
+    @Override
+    public long size() {
+        return size;
+    }
+
+    @Override
+    public SeekableByteChannel truncate(long newSize) {
+        if (size > newSize) {
+            size = (int) newSize;
+        }
+        repositionIfNecessary();
+        return this;
+    }
+
+    @Override
+    public int read(ByteBuffer buf) throws IOException {
+        ensureOpen();
+        repositionIfNecessary();
+        int wanted = buf.remaining();
+        int possible = size - position;
+        if (possible <= 0) {
+            return -1;
+        }
+        if (wanted > possible) {
+            wanted = possible;
+        }
+        buf.put(data, position, wanted);
+        position += wanted;
+        return wanted;
+    }
+
+    @Override
+    public void close() {
+        closed.set(true);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed.get();
+    }
+
+    @Override
+    public int write(ByteBuffer b) throws IOException {
+        ensureOpen();
+        int wanted = b.remaining();
+        int possibleWithoutResize = size - position;
+        if (wanted > possibleWithoutResize) {
+            int newSize = position + wanted;
+            if (newSize < 0) { // overflow
+                resize(Integer.MAX_VALUE);
+                wanted = Integer.MAX_VALUE - position;
+            } else {
+                resize(newSize);
+            }
+        }
+        b.get(data, position, wanted);
+        position += wanted;
+        if (size < position) {
+            size = position;
+        }
+        return wanted;
+    }
+
+    /**
+     * Obtains the array backing this channel.
+     *
+     * <p>NOTE:
+     * The returned buffer is not aligned with containing data, use
+     * {@link #size()} to obtain the size of data stored in the buffer.</p>
+     *
+     * @return internal byte array.
+     */
+    public byte[] array() {
+        return data;
+    }
+
+    private void resize(int newLength) {
+        int len = data.length;
+        if (len <= 0) {
+            len = 1;
+        }
+        if (newLength < NAIVE_RESIZE_LIMIT) {
+            while (len < newLength) {
+                len <<= 1;
+            }
+        } else { // avoid overflow
+            len = newLength;
+        }
+        data = Arrays.copyOf(data, len);
+    }
+
+    private void ensureOpen() throws ClosedChannelException {
+        if (!isOpen()) {
+            throw new ClosedChannelException();
+        }
+    }
+
+    private void repositionIfNecessary() {
+        if (position > size) {
+            position = size;
+        }
+    }
+
+}

--- a/lucene/core/src/test/org/apache/lucene/util/crypto/TestCrypto.java
+++ b/lucene/core/src/test/org/apache/lucene/util/crypto/TestCrypto.java
@@ -16,9 +16,7 @@
  */
 package org.apache.lucene.util.crypto;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
@@ -26,11 +24,7 @@ import java.util.Base64;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 
-import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
-import org.apache.commons.crypto.stream.CtrCryptoInputStream;
 import org.apache.lucene.util.LuceneTestCase;
-
-import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 
 public class TestCrypto extends LuceneTestCase {
 
@@ -107,7 +101,6 @@ public class TestCrypto extends LuceneTestCase {
     long pos = 0;    
     channel.position(pos);
 
-    CtrCryptoInputStream input = null;
     CtrCipher cipher = Crypto.getCtrDecryptCipher(key, iv);
 
     try {
@@ -123,16 +116,6 @@ public class TestCrypto extends LuceneTestCase {
         }
 
         byte[] plaintextChunk = Arrays.copyOfRange(plainbytes, (int) pos, (int) pos + n);
-        
-        // decrypt using GetCtrCryptoInputStream
-        ByteBufferBackedInputStream bbis = new ByteBufferBackedInputStream(bb);
-        input = Crypto.GetCtrCryptoInputStream(bbis, key.getEncoded(), iv.getIV(), pos);
-        ByteBuffer streamedResultBuf = ByteBuffer.allocate(n);
-        int r = input.read(streamedResultBuf);
-
-        // System.out.println("decrypt1 " + r + ": " + new String(streamedResultBuf.array()));
-        assertArrayEquals(plaintextChunk, streamedResultBuf.array());
-        bb.reset();
 
         // decrypt using CtrCipher#decrypt (non-stream, bytes)
         byte[] bytes = Arrays.copyOfRange(bb.array(), (int) pos, (int) pos + n);
@@ -149,25 +132,15 @@ public class TestCrypto extends LuceneTestCase {
         assertArrayEquals(plaintextChunk, resultBytes2);
         bb.reset();
 
-        bb.put(streamedResultBuf.rewind());
+        bb.put(resultBytes);
 
         pos += n;
         readLength -= n;
       }
       assert readLength == 0;
-    } catch (GeneralSecurityException e) {
-      throw new IOException(e.getMessage() + ": " + this, e);
     } finally {
       // System.out.println(new String(bb.array()));
       assertArrayEquals(Arrays.copyOfRange(plainbytes, 0, totalLength), bb.array());
-      
-      try {
-        if (input != null) {
-          input.close();
-        }
-      } catch (Exception e) {
-        // Noop
-      }
       try {
         channel.close();
       } catch (Exception e) {

--- a/lucene/core/src/test/org/apache/lucene/util/crypto/TestCrypto.java
+++ b/lucene/core/src/test/org/apache/lucene/util/crypto/TestCrypto.java
@@ -52,26 +52,34 @@ public class TestCrypto extends LuceneTestCase {
       "and these are called AEAD (authenticated encryption with associated data) schemes. For example, " +
       "EAX mode is a double-pass AEAD scheme while OCB mode is single-pass.";
 
-  public void testGenerateAesKey() throws NoSuchAlgorithmException {
-    SecretKey key = Crypto.GenerateAesKey();
-    String base64 = Base64.getEncoder().encodeToString(key.getEncoded());
-    System.out.println("AES Key: " + base64);
+  public void testGenerateAesKey() {
+    try {
+      SecretKey key = Crypto.generateAesKey();
+      String base64 = Base64.getEncoder().encodeToString(key.getEncoded());
+      System.out.println("AES Key: " + base64);
+    } catch (NoSuchAlgorithmException e) {
+      fail(e.getMessage());
+    }
   }
 
-  public void testGeneratedAesIv() throws NoSuchAlgorithmException {
-    IvParameterSpec iv = Crypto.GenerateAesIV();
-    String base64 = Base64.getEncoder().encodeToString(iv.getIV());
-    System.out.println("AES IV: " + base64);
+  public void testGeneratedAesIv() {
+    try {
+      IvParameterSpec iv = Crypto.generateAesIV();
+      String base64 = Base64.getEncoder().encodeToString(iv.getIV());
+      System.out.println("AES IV: " + base64);
+    } catch (NoSuchAlgorithmException e) {
+      fail(e.getMessage());
+    }
   }
 
   public void testFullDecrypt() throws Exception {  
     byte[] plainbytes = plaintext.getBytes();
     
-    Crypto.Initialize();
-    SecretKey key = Crypto.GenerateAesKey();
-    IvParameterSpec iv = Crypto.GenerateAesIV();
+    Crypto.initialize();
+    SecretKey key = Crypto.generateAesKey();
+    IvParameterSpec iv = Crypto.generateAesIV();
     
-    byte[] ciphertext = Crypto.EncryptAesCtr(key, iv, plainbytes);
+    byte[] ciphertext = Crypto.encryptAesCtr(key, iv, plainbytes);
     byte[] plaintext = Crypto.getCtrDecryptCipher(key, iv).decrypt(ciphertext);
     
     assertEquals(ciphertext.length, plaintext.length);
@@ -82,11 +90,11 @@ public class TestCrypto extends LuceneTestCase {
   public void testPositionCryptoRead() throws Exception {
     byte[] plainbytes = plaintext.getBytes();
 
-    Crypto.Initialize();
-    SecretKey key = Crypto.GenerateAesKey();
-    IvParameterSpec iv = Crypto.GenerateAesIV();
+    Crypto.initialize();
+    SecretKey key = Crypto.generateAesKey();
+    IvParameterSpec iv = Crypto.generateAesIV();
     
-    byte[] ciphertext = Crypto.EncryptAesCtr(key, iv, plainbytes);
+    byte[] ciphertext = Crypto.encryptAesCtr(key, iv, plainbytes);
    
     final int totalLength = 100 + random().nextInt(plainbytes.length - 100);
     
@@ -121,14 +129,14 @@ public class TestCrypto extends LuceneTestCase {
         byte[] bytes = Arrays.copyOfRange(bb.array(), (int) pos, (int) pos + n);
         byte[] resultBytes = cipher.decrypt(bytes, pos);
         
-        // System.out.println("decrypt2 " + resultBytes.length + ": " + new String(resultBytes));
+        // System.out.println("decrypt " + resultBytes.length + ": " + new String(resultBytes));
         assertArrayEquals(plaintextChunk, resultBytes);
         bb.reset();
         
         // decrypt using CtrCipher#decrypt (non-stream, ByteBuffer)
         byte[] resultBytes2 = cipher.decrypt(bb, pos);
         
-        // System.out.println("decrypt3 " + resultBytes2.length + ": " + new String(resultBytes2));
+        // System.out.println("decrypt2 " + resultBytes2.length + ": " + new String(resultBytes2));
         assertArrayEquals(plaintextChunk, resultBytes2);
         bb.reset();
 

--- a/lucene/misc/build.xml
+++ b/lucene/misc/build.xml
@@ -25,25 +25,6 @@
 
   <import file="../module-build.xml"/>
 
-  <path id="classpath">
-    <path refid="base.classpath"/>
-    <fileset dir="lib"/>
-  </path>
-
-  <path id="test.classpath">
-    <path refid="classpath"/>
-    <pathelement location="${common.dir}/build/codecs/classes/java"/>
-    <pathelement location="${common.dir}/build/test-framework/classes/java"/>
-    <path refid="junit-path"/>
-    <pathelement location="${build.dir}/classes/java"/>
-    <pathelement location="${build.dir}/classes/test"/>
-  </path>
-
-  <path id="junit.classpath">
-    <path refid="test.classpath"/>
-    <pathelement path="${java.class.path}"/>
-  </path>
-
   <target name="install-cpptasks" unless="cpptasks.uptodate" depends="ivy-availability-check,ivy-fail,ivy-configure">
     <property name="cpptasks.uptodate" value="true"/>
     <ivy:cachepath organisation="ant-contrib" module="cpptasks" revision="1.0b5"

--- a/lucene/misc/ivy.xml
+++ b/lucene/misc/ivy.xml
@@ -18,12 +18,4 @@
 -->
 <ivy-module version="2.0">
   <info organisation="org.apache.lucene" module="misc"/>
-  <configurations defaultconfmapping="compile->master">
-    <conf name="compile" transitive="false"/>
-  </configurations>
-  <dependencies>
-    <dependency org="org.apache.commons" name="commons-crypto" rev="${/org.apache.commons/commons-crypto}" conf="compile"/>
-    <dependency org="org.apache.commons" name="commons-compress" rev="${/org.apache.commons/commons-compress}" conf="compile"/>
-    <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="${/com.fasterxml.jackson.core/jackson-databind}" conf="compile"/>
-  </dependencies>
 </ivy-module>

--- a/lucene/misc/src/java/org/apache/lucene/store/RAFDirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/store/RAFDirectory.java
@@ -152,7 +152,7 @@ public class RAFDirectory extends FSDirectory {
         
         CtrCipher cipher = null;
         if (Crypto.isEncryptionOn()) {
-          cipher = Crypto.getCtrDecryptCipher(Crypto.GetAesKey(), Crypto.GetAesIV());        
+          cipher = Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
         }
 
         try {

--- a/lucene/test-framework/ivy.xml
+++ b/lucene/test-framework/ivy.xml
@@ -27,9 +27,6 @@
     <dependency org="junit" name="junit" rev="${/junit/junit}" conf="compile"/>
     <dependency org="org.hamcrest" name="hamcrest-core" rev="${/org.hamcrest/hamcrest-core}" conf="compile"/>
     <dependency org="com.carrotsearch.randomizedtesting" name="randomizedtesting-runner" rev="${/com.carrotsearch.randomizedtesting/randomizedtesting-runner}" conf="compile"/>
-    <dependency org="org.apache.commons" name="commons-crypto" rev="${/org.apache.commons/commons-crypto}" conf="compile"/>
-    <dependency org="org.apache.commons" name="commons-compress" rev="${/org.apache.commons/commons-compress}" conf="compile"/>
-    <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="${/com.fasterxml.jackson.core/jackson-databind}" conf="compile"/>
     <exclude org="*" ext="*" matcher="regexp" type="${ivy.exclude.types}"/> 
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
- removes unused dependencies
  - I added a local copy of `SeekableInMemoryByteChannel` from `org.apache.commons.compress.utils` to be used in tests
- fixes naming inconsistencies
- minor API tweaks