### PR TITLE
Allow CtrCipher to encrypt

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -83,7 +83,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   private CtrCipher initCipher(boolean encryptable) {
     if (encryptable && Crypto.isEncryptionOn()) {
       try {
-        return Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
+        return Crypto.getCtrCipher(Crypto.getAesKey(), Crypto.getAesIV());
       } catch (IOException e) {
         return null;
       }      

--- a/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
@@ -175,7 +175,7 @@ public class NIOFSDirectory extends FSDirectory {
       
       CtrCipher cipher = null;
       if (Crypto.isEncryptionOn()) {
-        cipher = Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
+        cipher = Crypto.getCtrCipher(Crypto.getAesKey(), Crypto.getAesIV());
       }
 
       try {

--- a/lucene/core/src/java/org/apache/lucene/store/SimpleFSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/SimpleFSDirectory.java
@@ -172,7 +172,7 @@ public class SimpleFSDirectory extends FSDirectory {
         
         CtrCipher cipher = null;
         if (Crypto.isEncryptionOn()) {
-          cipher = Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
+          cipher = Crypto.getCtrCipher(Crypto.getAesKey(), Crypto.getAesIV());
         }
 
         try {

--- a/lucene/core/src/java/org/apache/lucene/util/crypto/Crypto.java
+++ b/lucene/core/src/java/org/apache/lucene/util/crypto/Crypto.java
@@ -26,9 +26,7 @@ import java.security.Security;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
@@ -64,6 +62,7 @@ public final class Crypto {
   }
 
   public static SecretKey getAesKey() {
+    // TODO fetch from API
     if (isEncryptionOn()) {
       return TEST_AES_KEY;
     }
@@ -71,6 +70,7 @@ public final class Crypto {
   }
 
   public static IvParameterSpec getAesIV() {
+    // TODO fetch from API
     if (isEncryptionOn()) {
       return TEST_AES_IV;
     }
@@ -89,7 +89,7 @@ public final class Crypto {
     return new IvParameterSpec(iv);
   }
 
-  static SecureRandom getSecureRandom() throws NoSuchAlgorithmException {
+  private static SecureRandom getSecureRandom() throws NoSuchAlgorithmException {
     if (rand == null) {
       synchronized (Crypto.class) {
         if (rand == null) {
@@ -105,23 +105,15 @@ public final class Crypto {
       Cipher cipher = Cipher.getInstance(CTR_TRANSFORM);
       cipher.init(Cipher.ENCRYPT_MODE, key, iv);
       return cipher;
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException
+        | InvalidAlgorithmParameterException e) {
       throw new IOException(e);
     }
   }
 
-  public static byte[] encryptAesCtr(SecretKey key, IvParameterSpec iv, byte[] plaintext)
-      throws IOException {
-    try {
-      Cipher cipher = getCtrEncryptCipher(key, iv);
-      return cipher.doFinal(plaintext);
-    } catch (IllegalBlockSizeException | BadPaddingException e) {
-      throw new IOException(e);
-    }
-  }
-
-  public static CtrCipher getCtrDecryptCipher(SecretKey key, IvParameterSpec iv) throws IOException {
+  // TODO: Rethink the design
+  public static CtrCipher getCtrCipher(SecretKey key, IvParameterSpec iv) throws IOException {
     return new CtrCipher(key, iv);
   }
-  
+
 }

--- a/lucene/misc/src/java/org/apache/lucene/store/RAFDirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/store/RAFDirectory.java
@@ -152,7 +152,7 @@ public class RAFDirectory extends FSDirectory {
         
         CtrCipher cipher = null;
         if (Crypto.isEncryptionOn()) {
-          cipher = Crypto.getCtrDecryptCipher(Crypto.getAesKey(), Crypto.getAesIV());
+          cipher = Crypto.getCtrCipher(Crypto.getAesKey(), Crypto.getAesIV());
         }
 
         try {


### PR DESCRIPTION
also encryption tests added.

This will enable us to use Lucene's `CtrCipher` also in elasticsearch
Part of https://github.com/overnest/strongdoc/issues/38