### PR TITLE
Fix CtrCipher and tests

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/index/TestBackwardsCompatibility.java
@@ -81,6 +81,7 @@ import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.util.crypto.Crypto;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -95,6 +96,11 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
   public void beforeFunction() {
     // This test is done with premade unencrypted indexes. Need to turn off encryption
     Crypto.setEncryptionOn(false);
+  }
+
+  @After
+  public void afterFunction() {
+    Crypto.setEncryptionOn(true);
   }
 
   // Backcompat index generation, described below, is mostly automated in: 

--- a/lucene/core/src/test/org/apache/lucene/index/TestReadOnlyIndex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReadOnlyIndex.java
@@ -67,6 +67,7 @@ public class TestReadOnlyIndex extends LuceneTestCase {
   @AfterClass
   public static void afterClass() throws Exception {
     indexPath = null;
+    Crypto.setEncryptionOn(true);
   }
   
   public void testReadOnlyIndex() throws Exception {


### PR DESCRIPTION
1. Turned encryption back on in tests where it was turned off
2. For some reason `EncryptedFileChannel` will not work when `Cipher` is initialized in `CtrCipher` constructor 
PS: This fix is already present in the lucene jar that is part of https://github.com/overnest/elasticsearch/pull/3